### PR TITLE
Update existing modules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
-# Workaround for errors on module deployment: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8840
+# Workaround for errors on module deployment:
+# https://docs.microsoft.com/en-us/azure/templates/microsoft.automation/automationaccounts/modules
+# https://github.com/terraform-providers/terraform-provider-azurerm/issues/8840
 resource "azurerm_resource_group_template_deployment" "this" {
   for_each = { for i, module in var.modules : i => module }
 
@@ -6,13 +8,21 @@ resource "azurerm_resource_group_template_deployment" "this" {
   resource_group_name = var.resource_group_name
   deployment_mode     = "Incremental"
 
-  parameters = {
-    module_name = each.value.name
-    automation_account = var.automation_account_name
-    uri = each.value.uri
-  }
-
   template_content = file("${path.module}/module-template.json")
+
+  parameters_content = templatefile("${path.module}/module-template.parameters.json",
+    {
+      module_name        = each.value.name
+      automation_account = var.automation_account_name
+      uri                = each.value.uri
+    }
+  )
+
+  lifecycle {
+    ignore_changes = [
+      name
+    ]
+  }
 
   tags = var.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,18 @@
-resource "azurerm_automation_module" "module" {
-  count                     = length(var.modules)
-  
-  name                      = var.modules[count.index].name
-  resource_group_name       = var.resource_group_name
-  automation_account_name   = var.automation_account_name
+# Workaround for errors on module deployment: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8840
+resource "azurerm_resource_group_template_deployment" "this" {
+  for_each = { for i, module in var.modules : i => module }
 
-  module_link {
-    uri = var.modules[count.index].uri
+  name                = "module-template-${each.value.name}-${formatdate("YYMMDDhhmmss", timestamp())}"
+  resource_group_name = var.resource_group_name
+  deployment_mode     = "Incremental"
+
+  parameters = {
+    module_name = each.value.name
+    automation_account = var.automation_account_name
+    uri = each.value.uri
   }
+
+  template_content = file("${path.module}/module-template.json")
+
+  tags = var.tags
 }

--- a/module-template.json
+++ b/module-template.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "module_name": { "type": "string" },
+        "automation_account": { "type": "string" },
+        "uri": { "type": "string" }
+    },
+    "resources": [
+        {
+            "name": "[concat(parameters('automation_account'), '/', parameters('module_name'))]",
+            "type": "Microsoft.Automation/automationAccounts/modules",
+            "apiVersion": "2015-10-31",
+            "properties": {
+                "contentLink": {
+                    "uri": "[parameters('uri')]"
+                }
+            }
+        }
+    ]
+}

--- a/module-template.json
+++ b/module-template.json
@@ -2,9 +2,9 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "module_name": { "type": "string" },
-        "automation_account": { "type": "string" },
-        "uri": { "type": "string" }
+        "module_name": { "type": "String" },
+        "automation_account": { "type": "String" },
+        "uri": { "type": "String" }
     },
     "resources": [
         {

--- a/module-template.parameters.json
+++ b/module-template.parameters.json
@@ -1,0 +1,11 @@
+{
+    "module_name": {
+        "value": "${module_name}"
+    },
+    "automation_account": {
+        "value": "${automation_account}"
+    },
+    "uri": {
+        "value": "${uri}"
+    }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output modules_id {
-  value = azurerm_automation_module.module.*.id
+output templates {
+  value = azurerm_resource_group_template_deployment.this
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,20 +1,26 @@
 variable "resource_group_name" {
-  description   = "(Required) The name of the resource group in which the Module is created. Changing this forces a new resource to be created."
-  type          = string
-  default       = ""
+  description = "(Required) The name of the resource group in which the Module is created. Changing this forces a new resource to be created."
+  type        = string
+  default     = ""
 }
 
 variable "automation_account_name" {
-  description   = "(Required) The name of the automation account in which the Module is created. Changing this forces a new resource to be created." 
-  type          = string
-  default       = ""
+  description = "(Required) The name of the automation account in which the Module is created. Changing this forces a new resource to be created."
+  type        = string
+  default     = ""
 }
 
 variable "modules" {
-  description   = "A list of maps of module to install. Where 'name' is the module name, and 'uri' is the URI of the module."
-  type          = list(object({
-    name        = string
-    uri         = string
+  description = "A list of maps of module to install. Where 'name' is the module name, and 'uri' is the URI of the module."
+  type = list(object({
+    name = string
+    uri  = string
   }))
-  default       = []
+  default = []
+}
+
+variable "tags" {
+  description = "A mapping of tags which should be assigned to the Resource Group Template Deployment."
+  type        = map
+  default     = {}
 }


### PR DESCRIPTION
The changes plan to address a limitation of `azurerm_automation_module ` resource: updating an existing module raises an error:

```bash
Error: A resource with the ID "/subscriptions/b5e4f7c7-7846-4385-876d-ef68182dd660/resourceGroups/rg-common-francecentral/providers/Microsoft.Automation/automationAccounts/aa-sslrenew-1cd709/modules/Azure" already exists - to be managed via Terraform this resource needs to be imported into the State. Please see the resource documentation for "azurerm_automation_module" for more information.
```

As a workaround, we use a deployment template.